### PR TITLE
feat/add-skip-delivery-flag

### DIFF
--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -3,7 +3,7 @@ class SendReplyJob < ApplicationJob
 
   def perform(message_id)
     message = Message.find(message_id)
-    return if message.additional_attributes&.dig('skip_delivery')
+    return if message.content_attributes&.dig('skip_delivery')
 
     conversation = message.conversation
     channel_name = conversation.inbox.channel.class.to_s

--- a/app/jobs/send_reply_job.rb
+++ b/app/jobs/send_reply_job.rb
@@ -3,6 +3,8 @@ class SendReplyJob < ApplicationJob
 
   def perform(message_id)
     message = Message.find(message_id)
+    return if message.additional_attributes&.dig('skip_delivery')
+
     conversation = message.conversation
     channel_name = conversation.inbox.channel.class.to_s
 

--- a/app/workers/email_reply_worker.rb
+++ b/app/workers/email_reply_worker.rb
@@ -4,6 +4,7 @@ class EmailReplyWorker
 
   def perform(message_id)
     message = Message.find(message_id)
+    return if message.additional_attributes&.dig('skip_delivery')
 
     return unless message.email_notifiable_message?
 

--- a/app/workers/email_reply_worker.rb
+++ b/app/workers/email_reply_worker.rb
@@ -4,7 +4,7 @@ class EmailReplyWorker
 
   def perform(message_id)
     message = Message.find(message_id)
-    return if message.additional_attributes&.dig('skip_delivery')
+    return if message.content_attributes&.dig('skip_delivery')
 
     return unless message.email_notifiable_message?
 

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SendReplyJob do
       twilio_channel = create(:channel_twilio_sms)
       message = create(:message,
                         conversation: create(:conversation, inbox: twilio_channel.inbox),
-                        additional_attributes: { 'skip_delivery' => true })
+                        content_attributes: { 'skip_delivery' => true })
       allow(Twilio::SendOnTwilioService).to receive(:new).with(message: message).and_return(process_service)
       described_class.perform_now(message.id)
       expect(Twilio::SendOnTwilioService).not_to have_received(:new)

--- a/spec/jobs/send_reply_job_spec.rb
+++ b/spec/jobs/send_reply_job_spec.rb
@@ -11,6 +11,25 @@ RSpec.describe SendReplyJob do
       .on_queue('high')
   end
 
+  context 'when message has skip_delivery flag' do
+    let(:process_service) { double }
+
+    before do
+      allow(process_service).to receive(:perform)
+    end
+
+    it 'does not call any delivery service' do
+      twilio_channel = create(:channel_twilio_sms)
+      message = create(:message,
+                        conversation: create(:conversation, inbox: twilio_channel.inbox),
+                        additional_attributes: { 'skip_delivery' => true })
+      allow(Twilio::SendOnTwilioService).to receive(:new).with(message: message).and_return(process_service)
+      described_class.perform_now(message.id)
+      expect(Twilio::SendOnTwilioService).not_to have_received(:new)
+      expect(process_service).not_to have_received(:perform)
+    end
+  end
+
   context 'when the job is triggered on a new message' do
     let(:process_service) { double }
 

--- a/spec/workers/email_reply_worker_spec.rb
+++ b/spec/workers/email_reply_worker_spec.rb
@@ -11,6 +11,25 @@ RSpec.describe EmailReplyWorker, type: :worker do
   let(:mailer_action) { double }
 
   describe '#perform' do
+    context 'when message has skip_delivery flag' do
+      let(:skip_delivery_message) do
+        create(:message, message_type: :outgoing, inbox: channel.inbox, account: account,
+                         additional_attributes: { 'skip_delivery' => true })
+      end
+
+      before do
+        allow(ConversationReplyMailer).to receive(:with).and_return(mailer)
+        allow(mailer).to receive(:email_reply).and_return(mailer_action)
+        allow(mailer_action).to receive(:deliver_now).and_return(true)
+      end
+
+      it 'does not call mailer action' do
+        described_class.new.perform(skip_delivery_message.id)
+        expect(mailer).not_to have_received(:email_reply)
+        expect(mailer_action).not_to have_received(:deliver_now)
+      end
+    end
+
     context 'when emails are successfully sent' do
       before do
         allow(ConversationReplyMailer).to receive(:with).and_return(mailer)

--- a/spec/workers/email_reply_worker_spec.rb
+++ b/spec/workers/email_reply_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EmailReplyWorker, type: :worker do
     context 'when message has skip_delivery flag' do
       let(:skip_delivery_message) do
         create(:message, message_type: :outgoing, inbox: channel.inbox, account: account,
-                         additional_attributes: { 'skip_delivery' => true })
+                         content_attributes: { 'skip_delivery' => true })
       end
 
       before do


### PR DESCRIPTION
# Pull Request Template

## Description


## Change Summary

### Problem
Creating outgoing messages via the Account API triggers `SendReplyJob` and `EmailReplyWorker`, causing real delivery to recipients (Twilio, Email, etc.). This blocks safe migration of legacy conversations into Chatwoot.

### Solution
Added a `skip_delivery` guard to both delivery jobs. When `content_attributes.skip_delivery` is `true` on a message, delivery is silently skipped.

### Files Changed

| File | Change |
|---|---|
| `app/jobs/send_reply_job.rb` | Early return if `skip_delivery` is set |
| `app/workers/email_reply_worker.rb` | Early return if `skip_delivery` is set |
| `spec/jobs/send_reply_job_spec.rb` | Test: no delivery service called when flag is set |
| `spec/workers/email_reply_worker_spec.rb` | Test: mailer not called when flag is set |

### Usage
Pass `skip_delivery: true` in `content_attributes` when creating migrated messages:

```json
{
  "content": "Migrated message",
  "message_type": "outgoing",
  "content_attributes": { "skip_delivery": true }
}
```

### Zero impact on normal flow
The flag key is absent from all standard message paths — agent replies, campaigns, automations, macros, and templates are completely unaffected.

---

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
